### PR TITLE
feature/incipit search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # dependencies
 node_modules/
 
-# built files
-build/
-
 # log files
 yarn-error.log
 
@@ -20,3 +17,4 @@ output/
 # python environment
 env/
 venv/
+__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
-
 python:
-  - "3.5"
-
+- '3.5'
 install:
-  - pip install -r requirements/test.txt
-
+- pip install -r requirements/test.txt
 script:
-  - python -m pytest
-
+- python -m pytest
+notifications:
+  slack:
+    secure: PCnpBekm4nsLEX+96e2JGkg78nBnZKwt/VMcmpCMkr9AlncPFUkU45pMNiIHVe16xSJOjsnXRtqbJkZkrW980ohdG65RIyTBnWpI7VWtI9HyuSuBkie4BHHv/kIfGqwR3hGbcbEKHGYo4YP4hD01S+OIh6njZcUhw5vTcGAcSIyNjn/r20wSvGNenv4RQDE4Dt9e+Eq0D0QotGl97V0vkpH2o+s0878T+N+A/rudY35rK+Z8x06QMd/3MA5vnle19is3hVKXYaZNMuFcQUTCK4LHVGSSMJCphotSbfb9nqu6c1YblJCvfUXlA1o5nujse5y4cbG41hGWUFS5xad8LWfrGqgXdNd+9qzlXkbl3fuFmM8dYvgJBdTt3GM7Yu9ZyxcaXb527zNrL06SiYbwKaRNu6FmhdJ7mqa/R3jeNUaBmls42+Nvi9pMEblUsv4Q7RNo0TsTCqFJaKM2f7c5yYNr/NwaogV+dADsWtheCpGz/i1HDbjHh3tKnPsTf/YGMRRXQ2GvK1Pk65IaKzUGOjP04MtZeTfXmqoixg7Ai4ABPu98MFb7BlLXHWlyNA30d+XGP96qIflO27ATteA/JYx4QJU/R3CuOkgHtv5J355B3SIT/4I4V+Ah4rHKzp20b9FRKH9//sX9VKhR8tbQ2CGI32aBBtbXh0CLuQlUmPM=

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,3 @@
 ## production requirements
 
+flask

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,6 @@
 ## production requirements
 
 flask
-parasolr
+# require develop version of parasolr for needed updates
+git+https://github.com/Princeton-CDH/parasolr@develop#egg=parasolr
+#parasolr

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
 ## production requirements
 
 flask
+parasolr

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,11 @@
+import json
+import os
+
+# folder in which package.json is located
+pkg_path = os.path.dirname(os.path.dirname(__file__))
+
+# load package.json to get current version info
+with open(os.path.join(pkg_path, 'package.json')) as file:
+    pkg = json.loads(file.read())
+
+__version__ = pkg['version']

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -45,7 +45,7 @@ def search():
                                       method='unified', fragsize=0) \
             .search(incipit_txt_gez=search_term) \
             .order_by('-score') \
-            .only('*', 'score')
+            .only('id', 'macomber_id_s', 'incipit_txt_gez', 'score')
 
     results = queryset.get_results()
     if search_term:

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -2,30 +2,35 @@
 '''
 An HTTP server that proxies requests to solr to search for similar incipits.
 
+Run a debug server for development with:
+    $ export FLASK_APP=scripts/server.py FLASK_ENV=development
+    $ flask run
+
 '''
 import json
+import os
 
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, g
 from parasolr.solr.client import SolrClient
 
-from . import __version__
+from scripts import __version__
 
-SOLR_URL = 'http://localhost:8983/solr/'
-SOLR_CORE = 'pemm'
+# read settings from environment on startup
+SOLR_URL = os.getenv('SOLR_URL', 'http://localhost:8983/solr/')
+SOLR_CORE = os.getenv('SOLR_CORE', 'pemm')
 
+# create a new flask app from this module
 app = Flask(__name__)
 
 @app.route('/')
 def root():
+    '''Display version info and a basic html search form.'''
     return render_template('index.html', version=__version__)
 
 @app.route('/search', methods=['POST'])
 def search():
-    # set up solr instance
-    solr = SolrClient(SOLR_URL, SOLR_CORE)
-
-    # search for the incipit
-    response = solr.query(q='incipit_txt_gez:"%s"' % request.form['incipit'])
+    '''Search for an incipit and return a list of similar results.'''
+    response = get_solr().query(q='incipit_txt_gez:"%s"' % request.form['incipit'])
 
     # if html response was requested, render results.html template
     if 'format' in request.form and request.form['format'] == 'html':
@@ -34,3 +39,10 @@ def search():
 
     # by default, return JSON
     return json.dumps(response.docs)
+
+def get_solr():
+    '''Get a shared-per-request connection to solr, creating if none exists.'''
+    # see https://flask.palletsprojects.com/en/1.1.x/api/#flask.g
+    if 'solr' not in g:
+        g.solr = SolrClient(SOLR_URL, SOLR_CORE)
+    return g.solr

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -7,10 +7,9 @@ Run a debug server for development with:
     $ flask run
 
 '''
-import json
 import os
 
-from flask import Flask, render_template, request, g
+from flask import Flask, g, jsonify, render_template, request
 from parasolr.solr.client import SolrClient
 
 from scripts import __version__
@@ -22,10 +21,12 @@ SOLR_CORE = os.getenv('SOLR_CORE', 'pemm')
 # create a new flask app from this module
 app = Flask(__name__)
 
+
 @app.route('/')
 def root():
     '''Display version info and a basic html search form.'''
     return render_template('index.html', version=__version__)
+
 
 @app.route('/search', methods=['POST'])
 def search():
@@ -35,10 +36,11 @@ def search():
     # if html response was requested, render results.html template
     if 'format' in request.form and request.form['format'] == 'html':
         return render_template('results.html', results=response.docs,
-                                total=response.numFound)
+                               total=response.numFound)
 
     # by default, return JSON
-    return json.dumps(response.docs)
+    return jsonify(response.docs)
+
 
 def get_solr():
     '''Get a shared-per-request connection to solr, creating if none exists.'''

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+'''
+An HTTP server that proxies requests to solr to search for similar incipits.
+
+'''
+import json
+
+from flask import Flask, render_template, request
+from parasolr.solr.client import SolrClient
+
+from . import __version__
+
+SOLR_URL = 'http://localhost:8983/solr/'
+SOLR_CORE = 'pemm'
+
+app = Flask(__name__)
+
+@app.route('/')
+def root():
+    return render_template('index.html', version=__version__)
+
+@app.route('/search', methods=['POST'])
+def search():
+    # set up solr instance
+    solr = SolrClient(SOLR_URL, SOLR_CORE)
+
+    # search for the incipit
+    response = solr.query(q='incipit_txt_gez:"%s"' % request.form['incipit'])
+
+    # if html response was requested, render results.html template
+    if 'format' in request.form and request.form['format'] == 'html':
+        return render_template('results.html', results=response.docs,
+                                total=response.numFound)
+
+    # by default, return JSON
+    return json.dumps(response.docs)

--- a/scripts/templates/index.html
+++ b/scripts/templates/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<head>
+    <title>incipit search</title>
+</head>
+<body>
+    <h1>incipit search</h1>
+    <p>version {{ version }}</p>
+    <form action="/search" method="post">    
+        <input type="text" name="incipit" size="200" placeholder="enter incipit"/>
+        <input type="hidden" name="format" value="html"/>
+        <br/>
+        <input type="submit"/>
+    </form>
+</body>
+</html>

--- a/scripts/templates/results.html
+++ b/scripts/templates/results.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<head>
+    <title>search results for {{ request.form.incipit }}</title>
+    <style>
+        li { margin-bottom: 0.5em; }
+        .id { color: brown; font-style: italic; }
+    </style>
+</head>
+<body>
+    <h1>search results</h1>
+    <p>{{ total }} total results for "{{ request.form.incipit }}"</p>
+    {% if results|length > 0 %}
+    <ol>
+        {% for result in results %}
+        <li>
+            <span>{{ result.incipit_txt_gez }}</span><br/>
+            <span class="id">{{ result.id }}</span>
+        </li>
+        {% endfor %}
+    </ol>
+    {% endif %}
+</body>
+</html>

--- a/scripts/templates/results.html
+++ b/scripts/templates/results.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <head>
-    <title>search results for {{ request.form.incipit }}</title>
+    <title>search results for {{ search_term }}</title>
     <style>
         li { margin-bottom: 0.5em; }
         .id { color: brown; font-style: italic; }
@@ -8,7 +8,7 @@
 </head>
 <body>
     <h1>search results</h1>
-    <p>{{ total }} result{% if total > 1 %}s{% endif %} for "{{ request.form.incipit }}"</p>
+    <p>{{ total }} result{% if total > 1 %}s{% endif %} for "{{ search_term }}"</p>
     {% if results|length > 0 %}
     <ol>
         {% for result in results %}

--- a/scripts/templates/results.html
+++ b/scripts/templates/results.html
@@ -1,23 +1,36 @@
 <!doctype html>
 <head>
-    <title>search results for {{ search_term }}</title>
+    <title>Search results for {{ search_term }}</title>
     <style>
+        body {font-size: 14pt; }
         li { margin-bottom: 0.5em; }
         .id { color: brown; font-style: italic; }
+        input[type=text] {font-size: 16pt; width: 90%;}
+        .score {float: right; color: gray;}
     </style>
 </head>
 <body>
-    <h1>search results</h1>
-    <p>{{ total }} result{% if total > 1 %}s{% endif %} for "{{ search_term }}"</p>
+   <h1>Search Results</h1>
+
+    <form action="/search" method="get">
+        <input type="text" name="incipit" size="200" placeholder="enter incipit"
+            value="{{ search_term }}"/>
+        <input type="hidden" name="format" value="html"/>
+        <br/>
+        <input type="submit"/>
+    </form>
+    <p>{{ total }} result{% if total > 1 %}s{% endif %}</p>
     {% if results|length > 0 %}
-    <ol>
+    <ul>
         {% for result in results %}
         <li>
-            <span>{{ result.incipit_txt_gez }}</span><br/>
+            <b>{{ result.macomber_id_s }}</b>
+            <span lang="gez">{{ result.incipit_txt_gez|safe }}</span><br/>
+            <span class="score">{{ result.score }}</span>
             <span class="id">{{ result.id }}</span>
         </li>
         {% endfor %}
-    </ol>
+    </ul>
     {% endif %}
 </body>
 </html>

--- a/scripts/templates/results.html
+++ b/scripts/templates/results.html
@@ -7,6 +7,7 @@
         .id { color: brown; font-style: italic; }
         input[type=text] {font-size: 16pt; width: 90%;}
         .score {float: right; color: gray;}
+        em {color: red; font-weight: bold; }
     </style>
 </head>
 <body>

--- a/scripts/templates/results.html
+++ b/scripts/templates/results.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <h1>search results</h1>
-    <p>{{ total }} total results for "{{ request.form.incipit }}"</p>
+    <p>{{ total }} result{% if total > 1 %}s{% endif %} for "{{ request.form.incipit }}"</p>
     {% if results|length > 0 %}
     <ol>
         {% for result in results %}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
+from flask import g
 import pytest
 
-from scripts import server
+from scripts import __version__, server
 
 # see the flask docs for an explanation of creating an example test client:
 # https://flask.palletsprojects.com/en/1.1.x/testing/#the-testing-skeleton
@@ -8,13 +11,37 @@ from scripts import server
 # see also the docs on mocking the 'g' context object:
 # https://flask.palletsprojects.com/en/1.1.x/testing/#faking-resources
 
+
 @pytest.fixture
 def client():
     # FIXME incomplete
     server.app.config['TESTING'] = True
 
-    with server.app.test_client() as client:
-        with server.app.app_context():
-            pass
-        yield client
+    with server.app.test_client() as client, server.app.app_context():
+            yield client
+
+
+def test_index(client):
+    # check home page
+    rv = client.get('/')
+    print(rv.data)
+    assert 'version %s' % __version__ in rv.data.decode()
+    assert b'<form action="/search" method="post">' in rv.data
+    assert b'<input type="hidden" name="format" value="html"/>' in rv.data
+    assert b'<input type="text" name="incipit"' in rv.data
+
+
+@patch('scripts.server.SolrClient')
+def test_get_solr(mocksolrclient, client):
+    assert 'solr' not in g
+    # should initialize solr client and store in app context global
+    server.get_solr()
+    assert 'solr' in g
+    mocksolrclient.assert_called_with(server.SOLR_URL, server.SOLR_CORE)
+
+    # if called again, should not re-initialize
+    mocksolrclient.reset_mock()
+    server.get_solr()
+    mocksolrclient.assert_not_called()
+
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,7 +77,8 @@ def test_search(mocksolrqueryset, client):
     mocksolrqueryset.assert_called_with(g.solr)
     mocksqs.search.assert_called_with(incipit_txt_gez=test_search_string)
     mocksqs.order_by.assert_called_with('-score')
-    mocksqs.only.assert_called_with('*', 'score')
+    mocksqs.only.assert_called_with(
+        'id', 'macomber_id_s', 'incipit_txt_gez', 'score')
     mocksqs.highlight.assert_called_with(
         'incipit_txt_gez', q=test_search_string, method='unified', fragsize=0)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,12 +69,15 @@ def test_search(mocksolrqueryset, client):
     rv = client.post('/search', data=dict(
         incipit=test_search_string, format='html'
     ))
-    assert b'search results' in rv.data
-    assert '1 result for "%s"' % test_search_string in rv.data.decode()
+    assert b'Search Results' in rv.data
+    assert b'1 result' in rv.data
+    # search string set as input value
+    assert 'value="%s"' % test_search_string in rv.data.decode()
     assert test_solr_docs[0]['id'] in rv.data.decode()
     assert test_solr_docs[0]['incipit_txt_gez'] in rv.data.decode()
 
     # also handle GET
     rv = client.get('/search?incipit=%s&format=html' % test_search_string)
-    assert b'search results' in rv.data
-    assert '1 result for "%s"' % test_search_string in rv.data.decode()
+    assert b'Search Results' in rv.data
+    assert 'value="%s"' % test_search_string in rv.data.decode()
+    assert b'1 result' in rv.data

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,9 +14,7 @@ from scripts import __version__, server
 
 @pytest.fixture
 def client():
-    # FIXME incomplete
     server.app.config['TESTING'] = True
-
     with server.app.test_client() as client, server.app.app_context():
             yield client
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,20 @@
+import pytest
+
+from scripts import server
+
+# see the flask docs for an explanation of creating an example test client:
+# https://flask.palletsprojects.com/en/1.1.x/testing/#the-testing-skeleton
+
+# see also the docs on mocking the 'g' context object:
+# https://flask.palletsprojects.com/en/1.1.x/testing/#faking-resources
+
+@pytest.fixture
+def client():
+    # FIXME incomplete
+    server.app.config['TESTING'] = True
+
+    with server.app.test_client() as client:
+        with server.app.app_context():
+            pass
+        yield client
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,19 +51,35 @@ def test_search(mocksolrqueryset, client):
 
     # simulate queryset fluent interface
     mocksqs = mocksolrqueryset.return_value
-    for method in ['search', 'order_by', 'only']:
+    for method in ['search', 'order_by', 'only', 'highlight']:
         getattr(mocksqs, method).return_value = mocksqs
 
     test_solr_docs = [
         {'id': '1-A', 'incipit_txt_gez': 'በእንተ፡ ዘከመ፡ አስተርአየቶ፡'}
     ]
+    mock_highlighting = {
+        '1-A': {
+            "incipit_txt_gez": ["<em>ዘከመ</em>፡ ተስእላ፡ ሠለስቱ፡ ደናግል፡"]
+        }
+    }
     mocksqs.get_results.return_value = test_solr_docs
     mocksqs.count.return_value = 1
+    mocksqs.get_highlighting.return_value = mock_highlighting
 
     test_search_string = 'አስተርአየቶ'
     rv = client.post('/search', data=dict(incipit=test_search_string))
-    assert rv.get_json() == test_solr_docs
+    json_data = rv.get_json()
+    assert json_data == test_solr_docs
+    # result should use highlighted version of incipit
+    assert json_data[0]['incipit_txt_gez'] == \
+        mock_highlighting['1-A']['incipit_txt_gez'][0]
+
     mocksolrqueryset.assert_called_with(g.solr)
+    mocksqs.search.assert_called_with(incipit_txt_gez=test_search_string)
+    mocksqs.order_by.assert_called_with('-score')
+    mocksqs.only.assert_called_with('*', 'score')
+    mocksqs.highlight.assert_called_with(
+        'incipit_txt_gez', q=test_search_string, method='unified', fragsize=0)
 
     # request html
     rv = client.post('/search', data=dict(
@@ -74,9 +90,10 @@ def test_search(mocksolrqueryset, client):
     # search string set as input value
     assert 'value="%s"' % test_search_string in rv.data.decode()
     assert test_solr_docs[0]['id'] in rv.data.decode()
-    assert test_solr_docs[0]['incipit_txt_gez'] in rv.data.decode()
+    # make sure highlighted version is displayed
+    assert mock_highlighting['1-A']['incipit_txt_gez'][0] in rv.data.decode()
 
-    # also handle GET
+    # handle GET the same way as POST
     rv = client.get('/search?incipit=%s&format=html' % test_search_string)
     assert b'Search Results' in rv.data
     assert 'value="%s"' % test_search_string in rv.data.decode()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,7 +47,7 @@ def test_get_solr(mocksolrclient, client):
 @patch('scripts.server.SolrClient')
 def test_search(mocksolrclient, client):
     test_solr_result = Mock(docs=[
-        {'id': 1}
+        {'id': '1-A', 'incipit_txt_gez': 'በእንተ፡ ዘከመ፡ አስተርአየቶ፡'}
     ], numFound=1)
     mocksolrclient.return_value.query.return_value = test_solr_result
     mocksolrclient.return_value.query.return_value = test_solr_result
@@ -62,4 +62,10 @@ def test_search(mocksolrclient, client):
     ))
     assert b'search results' in rv.data
     assert '1 result for "%s"' % test_search_string in rv.data.decode()
+    assert test_solr_result.docs[0]['id'] in rv.data.decode()
+    assert test_solr_result.docs[0]['incipit_txt_gez'] in rv.data.decode()
 
+    # also handle GET
+    rv = client.get('/search?incipit=%s&format=html' % test_search_string)
+    assert b'search results' in rv.data
+    assert '1 result for "%s"' % test_search_string in rv.data.decode()


### PR DESCRIPTION
creating this PR to add comments for handoff to @rlskoeser.

this was created from the `import-script` branch so that it could take advantage of all of the python-related changes and schema changes that were added in that branch without needing to cherry-pick everything. it also allows you to more easily regenerate the csvs, index them, and then test them in this branch.

this creates a new flask app in `scripts/server.py` with two routes:

- `/`, which returns a simple html form that shows the current software version (taken from `package.json`) and lets the user run a test query against solr. the form on this page has a hidden input that always sends `&format=html` to the `/search` endpoint (see below) so you can use it in the browser to test without needing to `curl`, etc.
- `/search`, which responds to POST with a list of matching incipits as JSON. if the querystring contains `&format=html` it will instead render a template with some basic styles that let the user more easily browse the results.

see the docstring in the `server.py` file for instructions on running the flask server. you will need to set the `SOLR_URL` and `SOLR_CORE` envvars (or use the defaults listed in that file). if you have `FLASK_ENV=development` the server will reload when you save `server.py`, and also give you debug output in responses.

i started to write tests in `tests/test_server.py` but didn't get very far - see the notes in that file for links to relevant flask documentation. it looks like there are established patterns for mocking the `g` object, so we can use that to provide a mock `SolrClient` for testing.