### PR TITLE
travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ jobs:
   include:
     - language: python
       python: 3.5
+      cache: pip
       before_install:
       - cp scripts/local_settings.cfg.sample scripts/local_settings.cfg
       install:
@@ -10,6 +11,7 @@ jobs:
       - python -m pytest
     - language: node_js
       node_js: 10
+      cache: yarn
       script:
       - yarn build
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
-language: python
-python:
-- '3.5'
-node_js:
-- 10
-before_install:
-- cp scripts/local_settings.cfg.sample scripts/local_settings.cfg
-install:
-- pip install -r requirements/test.txt
-- yarn install --frozen-lockfile
-script:
-- python -m pytest
-- yarn build
+jobs:
+  include:
+    - language: python
+      python: 3.5
+      before_install:
+      - cp scripts/local_settings.cfg.sample scripts/local_settings.cfg
+      install:
+      - pip install -r requirements/test.txt
+    - language: node_js
+      node_js: 10
 notifications:
   slack:
     secure: PCnpBekm4nsLEX+96e2JGkg78nBnZKwt/VMcmpCMkr9AlncPFUkU45pMNiIHVe16xSJOjsnXRtqbJkZkrW980ohdG65RIyTBnWpI7VWtI9HyuSuBkie4BHHv/kIfGqwR3hGbcbEKHGYo4YP4hD01S+OIh6njZcUhw5vTcGAcSIyNjn/r20wSvGNenv4RQDE4Dt9e+Eq0D0QotGl97V0vkpH2o+s0878T+N+A/rudY35rK+Z8x06QMd/3MA5vnle19is3hVKXYaZNMuFcQUTCK4LHVGSSMJCphotSbfb9nqu6c1YblJCvfUXlA1o5nujse5y4cbG41hGWUFS5xad8LWfrGqgXdNd+9qzlXkbl3fuFmM8dYvgJBdTt3GM7Yu9ZyxcaXb527zNrL06SiYbwKaRNu6FmhdJ7mqa/R3jeNUaBmls42+Nvi9pMEblUsv4Q7RNo0TsTCqFJaKM2f7c5yYNr/NwaogV+dADsWtheCpGz/i1HDbjHh3tKnPsTf/YGMRRXQ2GvK1Pk65IaKzUGOjP04MtZeTfXmqoixg7Ai4ABPu98MFb7BlLXHWlyNA30d+XGP96qIflO27ATteA/JYx4QJU/R3CuOkgHtv5J355B3SIT/4I4V+Ah4rHKzp20b9FRKH9//sX9VKhR8tbQ2CGI32aBBtbXh0CLuQlUmPM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ jobs:
       - cp scripts/local_settings.cfg.sample scripts/local_settings.cfg
       install:
       - pip install -r requirements/test.txt
+      script:
+      - python -m pytest
     - language: node_js
       node_js: 10
+      script:
+      - yarn build
 notifications:
   slack:
     secure: PCnpBekm4nsLEX+96e2JGkg78nBnZKwt/VMcmpCMkr9AlncPFUkU45pMNiIHVe16xSJOjsnXRtqbJkZkrW980ohdG65RIyTBnWpI7VWtI9HyuSuBkie4BHHv/kIfGqwR3hGbcbEKHGYo4YP4hD01S+OIh6njZcUhw5vTcGAcSIyNjn/r20wSvGNenv4RQDE4Dt9e+Eq0D0QotGl97V0vkpH2o+s0878T+N+A/rudY35rK+Z8x06QMd/3MA5vnle19is3hVKXYaZNMuFcQUTCK4LHVGSSMJCphotSbfb9nqu6c1YblJCvfUXlA1o5nujse5y4cbG41hGWUFS5xad8LWfrGqgXdNd+9qzlXkbl3fuFmM8dYvgJBdTt3GM7Yu9ZyxcaXb527zNrL06SiYbwKaRNu6FmhdJ7mqa/R3jeNUaBmls42+Nvi9pMEblUsv4Q7RNo0TsTCqFJaKM2f7c5yYNr/NwaogV+dADsWtheCpGz/i1HDbjHh3tKnPsTf/YGMRRXQ2GvK1Pk65IaKzUGOjP04MtZeTfXmqoixg7Ai4ABPu98MFb7BlLXHWlyNA30d+XGP96qIflO27ATteA/JYx4QJU/R3CuOkgHtv5J355B3SIT/4I4V+Ah4rHKzp20b9FRKH9//sX9VKhR8tbQ2CGI32aBBtbXh0CLuQlUmPM=


### PR DESCRIPTION
this uses travis's build matrix to do the javascript and python parts of ci separately. this means a few things:

- we can use the `language: node_js` and `node: [version]` options for the js part, without conflicting with `language: python` for the python part
- using `language: node_js` means that we don't need to specify an install step for the js part, since travis autodetects `yarn.lock` and runs the correct install step using it
- we can cache pip for the python part, and cache `node_modules` for the js part
- the two builds run concurrently, which speeds things up

i used [these travis docs](https://docs.travis-ci.com/user/build-matrix/#using-different-programming-languages-per-job) as a reference.